### PR TITLE
Update to latest `ZStore` for benchmarking

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -413,7 +413,7 @@ cfg_if::cfg_if! {
     }
 }
 
-// To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
+// To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
 // Then `cargo criterion --bench end2end`. The results are located in `target/criterion/data/<name-of-benchmark>`.
 // For flamegraphs, run `cargo criterion --bench end2end --features flamegraph -- --profile-time <secs>`.
 // The results are located in `target/criterion/profile/<name-of-benchmark>`.

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -147,7 +147,7 @@ struct Prove {
     #[clap(short = 'x', long, value_parser)]
     expression: Option<PathBuf>,
 
-    /// Path to proof input
+    /// Path to proof output
     #[clap(short, long, value_parser)]
     proof: PathBuf,
 

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -201,10 +201,9 @@ pub(crate) mod test {
     #[test]
     fn dummy_lang() {
         let store = &mut Store::<Fr>::default();
-        let mut lang = Lang::<Fr, Coproc<Fr>>::new();
-        let name = Symbol::sym(vec!["".into(), "cproc".into(), "dumb".into()]);
-        let dummy = DummyCoprocessor::new();
-
-        lang.add_coprocessor(name, dummy, store);
+        let _lang = Lang::<Fr, Coproc<Fr>>::new_with_bindings(
+            store,
+            vec![(".coproc.dummy", DummyCoprocessor::new().into())],
+        );
     }
 }

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -707,11 +707,23 @@ pub mod tests {
         ));
     }
 
+    #[test]
+    fn test_minus_zero_symbol() {
+        let x: Syntax<Scalar> = symbol!(["-0"]);
+        let text = format!("{}", x);
+        let (_, res)  = parse_syntax()(Span::new(&text)).expect("valid parse");
+        eprintln!("------------------");
+        eprintln!("{}", text);
+        eprintln!("{} {:?}", x, x);
+        eprintln!("{} {:?}", res, res);
+        assert_eq!(x, res)
+    }
+
     proptest! {
         #[test]
         fn prop_syntax(x in any::<Syntax<Scalar>>()) {
             let text = format!("{}", x);
-            let (_, res)  = parse_syntax()(Span::new(&text)).expect("valid parse");
+            let (_, res) = parse_syntax()(Span::new(&text)).expect("valid parse");
             eprintln!("------------------");
             eprintln!("x {} {:?}", x, x);
             eprintln!("res {} {:?}", res, res);

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -711,7 +711,7 @@ pub mod tests {
     fn test_minus_zero_symbol() {
         let x: Syntax<Scalar> = symbol!(["-0"]);
         let text = format!("{}", x);
-        let (_, res)  = parse_syntax()(Span::new(&text)).expect("valid parse");
+        let (_, res) = parse_syntax()(Span::new(&text)).expect("valid parse");
         eprintln!("------------------");
         eprintln!("{}", text);
         eprintln!("{} {:?}", x, x);

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -56,7 +56,7 @@ impl Registry {
             let pp = default(lang);
             disk_cache
                 .set(key, &*pp)
-                .tap_ok(|_| ()) //eprintln!("Writing public params to disk-cache: {}", lang_key))
+                .tap_ok(|_| eprintln!("Writing public params to disk-cache: {}", lang_key))
                 .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
             Ok(pp)
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -979,7 +979,6 @@ impl<F: LurkField> Store<F> {
         } else {
             let (z_ptr, z_expr) = match self.fetch(ptr) {
                 Some(Expression::Nil) => {
-                    // todo, add lurk_sym components
                     (ZExpr::Nil.z_ptr(&self.poseidon_cache), Some(ZExpr::Nil))
                 }
                 Some(Expression::Cons(car, cdr)) => {
@@ -1021,10 +1020,6 @@ impl<F: LurkField> Store<F> {
                     let z_expr = ZExpr::Thunk(z_value, z_cont);
                     (z_expr.z_ptr(&self.poseidon_cache), Some(z_expr))
                 }
-                None => {
-                    let (z_ptr, _) = self.get_z_expr(ptr, z_store.clone())?;
-                    (z_ptr, None)
-                }
                 Some(Expression::Char(c)) => {
                     let z_expr = ZExpr::Char(c);
                     (z_expr.z_ptr(&self.poseidon_cache), Some(z_expr))
@@ -1063,6 +1058,7 @@ impl<F: LurkField> Store<F> {
                     let z_expr = ZExpr::Key(z_car, z_cdr);
                     (z_expr.z_ptr(&self.poseidon_cache), Some(z_expr))
                 }
+                None => return Err(Error("get_z_expr unknown opaque".into())),
             };
             if let Some(z_store) = z_store {
                 z_store.borrow_mut().insert_z_expr(&z_ptr, z_expr.clone());
@@ -2469,7 +2465,6 @@ pub mod test {
     fn commit_and_open(store: &mut Store<S1>, expr: Ptr<S1>) -> Ptr<S1> {
         let secret = <S1>::random(OsRng);
         let comm = store.hide(secret, expr);
-        println!("Initial Commit: {:?}", comm);
 
         let (_, new_ptr) = store.open(comm).unwrap();
         assert_eq!(expr, new_ptr);

--- a/src/store.rs
+++ b/src/store.rs
@@ -72,8 +72,6 @@ pub struct Store<F: LurkField> {
     pub dehydrated: Vec<Ptr<F>>,
     pub dehydrated_cont: Vec<ContPtr<F>>,
 
-    // improve intern_str, intern_sym performance
-    //pub string_cache: CacheMap<String, Box<Ptr<F>>>,
     pub symbol_cache: CacheMap<Symbol, Box<Ptr<F>>>,
 
     pub constants: OnceCell<NamedConstants<F>>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -570,7 +570,7 @@ impl<F: LurkField> Store<F> {
         match self.str_cache.get(s) {
             Some(ptr_cache) => *ptr_cache,
             None => {
-                let tail = &s[1..s.len()];
+                let tail = &s.chars().skip(1).collect::<String>();
                 let tail_ptr = self.intern_string(tail);
                 let head = s.chars().next().unwrap();
                 let s_ptr = self.intern_strcons(self.intern_char(head), tail_ptr);

--- a/src/store.rs
+++ b/src/store.rs
@@ -961,22 +961,13 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    // TODO: add cycle detection to avoid infinite recursions
+    // TODO: add cycle detection to avoid infinite recursion
     pub fn get_z_expr(
         &self,
         ptr: &Ptr<F>,
         z_store: Option<Rc<RefCell<ZStore<F>>>>,
     ) -> Result<(ZExprPtr<F>, Option<ZExpr<F>>), Error> {
-        if let Some(idx) = ptr.raw.opaque_idx() {
-            let z_ptr = self
-                .opaque_ptrs
-                .get_index(idx)
-                .ok_or(Error("get_z_expr unknown opaque".into()))?;
-            // TODO: should we try to dereference the opaque pointer?
-            Ok((*z_ptr, None))
-        } else if let Some((z_ptr, z_expr)) = self.z_expr_ptr_cache.get(ptr) {
-            Ok((*z_ptr, z_expr.clone()))
-        } else {
+        let get_z_expr_aux = || {
             let (z_ptr, z_expr) = match self.fetch(ptr) {
                 Some(Expression::Nil) => {
                     (ZExpr::Nil.z_ptr(&self.poseidon_cache), Some(ZExpr::Nil))
@@ -1060,13 +1051,30 @@ impl<F: LurkField> Store<F> {
                 }
                 None => return Err(Error("get_z_expr unknown opaque".into())),
             };
-            if let Some(z_store) = z_store {
-                z_store.borrow_mut().insert_z_expr(&z_ptr, z_expr.clone());
-            };
             self.z_expr_ptr_map.insert(z_ptr, Box::new(*ptr));
             self.z_expr_ptr_cache
                 .insert(*ptr, Box::new((z_ptr, z_expr.clone())));
             Ok((z_ptr, z_expr))
+        };
+        if let Some(idx) = ptr.raw.opaque_idx() {
+            let z_ptr = self
+                .opaque_ptrs
+                .get_index(idx)
+                .ok_or(Error("get_z_expr unknown opaque".into()))?;
+            // TODO: should we try to dereference the opaque pointer?
+            Ok((*z_ptr, None))
+        } else {
+            // Store all children reachable from Ptr in ZStore
+            if let Some(z_store) = z_store.clone() {
+                let (z_ptr, z_expr) = get_z_expr_aux()?;
+                z_store.borrow_mut().insert_z_expr(&z_ptr, z_expr.clone());
+                Ok((z_ptr, z_expr))
+            // Check the Ptr cache, used extensively in hydration
+            } else if let Some((z_ptr, z_expr)) = self.z_expr_ptr_cache.get(ptr) {
+                Ok((*z_ptr, z_expr.clone()))
+            } else {
+                get_z_expr_aux()
+            }
         }
     }
 
@@ -2480,15 +2488,16 @@ pub mod test {
         let comm2 = commit_and_open(store, two);
         let comm3 = commit_and_open(store, three);
 
-        // Store/ZStore roundtrip conversion
         store.hydrate_scalar_cache();
+
         let (z_store, z_ptr) = ZStore::new_with_expr(store, &comm2);
         let z_ptr = z_ptr.unwrap();
 
         let (store, _ptr) = z_store.to_store_with_z_ptr(&z_ptr).unwrap();
-
         let (_, two_opened) = store.open(comm2).unwrap();
-        assert_eq!(two, two_opened);
+        // The `cons_store` indices are scrambled when converting to a ZStore, so we
+        // hash each pointer to check equality
+        assert!(store.ptr_eq(&two, &two_opened).unwrap());
 
         assert!(store.open(comm3).is_none());
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -75,7 +75,7 @@ pub struct Store<F: LurkField> {
     pub dehydrated_cont: Vec<ContPtr<F>>,
 
     str_cache: HashMap<Arc<str>, Ptr<F>>,
-    pub symbol_cache: CacheMap<Symbol, Box<Ptr<F>>>,
+    symbol_cache: HashMap<Symbol, Box<Ptr<F>>>,
 
     pub constants: OnceCell<NamedConstants<F>>,
 }
@@ -502,7 +502,7 @@ impl<F: LurkField> Store<F> {
                 _f: ptr._f,
             })
         } else {
-            Some(ptr)
+            Some(*ptr)
         }
     }
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -16,7 +16,9 @@ pub const ESCAPE_CHARS: &str = "|(){}[],.:'\\\"";
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 /// Type for hierarchical symbol names
 pub enum Symbol {
+    /// Represents a hierarchical symbol whose path is a vector of strings
     Sym(Vec<String>),
+    /// Represents a hierarchical keyword whose path is a vector of strings
     Key(Vec<String>),
 }
 

--- a/src/syntax_macros.rs
+++ b/src/syntax_macros.rs
@@ -173,7 +173,7 @@ macro_rules! list {
             $crate::syntax::Syntax::List(Pos::No, temp_vec)
         }
     };
-    ($f:ty,  [$( $x:expr ),*], $end:expr ) => {
+    ($f:ty, [$( $x:expr ),*], $end:expr ) => {
         {
             #[allow(unused_mut)]
             let mut temp_vec = Vec::new();
@@ -183,7 +183,7 @@ macro_rules! list {
             $crate::syntax::Syntax::<$f>::Improper(Pos::No, temp_vec, Box::new($end))
         }
     };
-    ($f:ty,  [$( $x:expr ),*] ) => {
+    ($f:ty, [$( $x:expr ),*] ) => {
         {
             #[allow(unused_mut)]
             let mut temp_vec = Vec::new();

--- a/src/z_data/serde/de.rs
+++ b/src/z_data/serde/de.rs
@@ -367,7 +367,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         match self.input {
             ZData::Cell(xs) if !xs.is_empty() => match &xs[0] {
                 ZData::Atom(idx_vec) if idx_vec.len() == 1 => {
-                    println!("Variants: {:?}", variants);
                     let variant = String::from(variants[idx_vec[0] as usize]);
                     visitor.visit_enum(Enum::new(self, variant, 1))
                 }

--- a/src/z_data/z_expr.rs
+++ b/src/z_data/z_expr.rs
@@ -221,14 +221,13 @@ mod tests {
         }
 
         #[test]
-        // Note: slow in non-release mode (~3 mins)
+        // TODO: Overflows stack in non-release mode
         fn prop_expr_z_expr_roundtrip(x in any::<Syntax<Scalar>>()) {
             let mut store = Store::<Scalar>::default();
             let ptr = store.intern_syntax(x);
             let expr = store.fetch(&ptr).unwrap();
-            let z_expr = ZExpr::from_ptr(&store, &ptr).unwrap();
-            let z_ptr = ZExpr::z_ptr(&z_expr, &PoseidonCache::default());
-            store.z_expr_ptr_map.insert(z_ptr, Box::new(ptr));
+
+            let z_ptr = store.hash_expr(&ptr).unwrap();
             let ptr_new = store.fetch_z_expr_ptr(&z_ptr).unwrap();
 
             assert_eq!(expr, store.fetch(&ptr_new).unwrap());

--- a/src/z_data/z_store.rs
+++ b/src/z_data/z_store.rs
@@ -62,14 +62,14 @@ impl<F: LurkField> ZStore<F> {
     }
 
     /// Creates a new `ZStore` and adds all `ZExprPtrs` reachable from the hashed `expr`
+    /// Inserts child pointers into `ZStore` with `to_z_store_with_ptr`,
+    /// then inserts top level pointer
+    /// Discards errors and returns an empty `ZStore` instead
     pub fn new_with_expr(store: &Store<F>, expr: &Ptr<F>) -> (Self, Option<ZExprPtr<F>>) {
-        let (mut new, z_ptr) = match store.to_z_store_with_ptr(expr) {
-            Ok((new, z_ptr)) => (new, z_ptr),
-            _ => return (ZStore::new(), None),
-        };
-        let z_expr = ZExpr::from_ptr(store, expr);
-        new.expr_map.insert(z_ptr, z_expr);
-        (new, Some(z_ptr))
+        match store.to_z_store_with_ptr(expr) {
+            Ok((new, z_ptr)) => (new, Some(z_ptr)),
+            _ => (ZStore::new(), None),
+        }
     }
 
     /// Converts a Lurk expression to a `ZExpr` and stores it in the `ZStore`, returning


### PR DESCRIPTION
This PR adds `ZPtr` caching for `store::get_z_expr`, which according to local benchmarks results in ~2x speedup during hydration and eliminates the 4% proving slowdown noticed during earlier benchmarks.

Note: The failing test `parser::tests::test_minus_zero_symbol` was added as a TODO, but appears to be broken on master as well and shouldn't affect benchmarking.

Joint work with @arthurpaulino