### PR TITLE
Progress on `MultiFrameTrait`

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -69,22 +69,24 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
 }
 
 impl<F: LurkField, C: Coprocessor<F>> FrameLike for Frame<IO<F>, Witness<F>, C> {
-    type FramePtr = IO<F>;
-    fn input(&self) -> &Self::FramePtr {
+    type FrameIO = IO<F>;
+    fn input(&self) -> &Self::FrameIO {
         &self.input
     }
-    fn output(&self) -> &Self::FramePtr {
+    fn output(&self) -> &Self::FrameIO {
         &self.output
     }
 }
 
 impl<'a, F: LurkField, C: Coprocessor<F>> FrameLike for CircuitFrame<'a, F, C> {
     // TODO: fix the inability to return an error here
-    type FramePtr = IO<F>;
-    fn input(&self) -> &Self::FramePtr {
+    // We *could* add an Error type here, but actually, this is a case where a builder pattern
+    // would resolve the initialization of these structures
+    type FrameIO = IO<F>;
+    fn input(&self) -> &Self::FrameIO {
         &self.input.unwrap()
     }
-    fn output(&self) -> &Self::FramePtr {
+    fn output(&self) -> &Self::FrameIO {
         &self.output.unwrap()
     }
 }
@@ -144,11 +146,11 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<F, C> for MultiFrame<'
         Ok(frames)
     }
 
-    fn to_io_vector(
+    fn io_to_scalar_vector(
         store: &Self::Store,
-        frame: &<Self::EvalFrame as FrameLike>::FramePtr,
+        io: &<Self::EvalFrame as FrameLike>::FrameIO,
     ) -> Result<Vec<F>, Self::StoreError> {
-        frame.to_vector(store)
+        io.to_vector(store)
     }
 
     fn compute_witness(&self, s: &Store<F>) -> WitnessCS<F> {
@@ -182,6 +184,10 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<F, C> for MultiFrame<'
 
     fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>> {
         &mut self.cached_witness
+    }
+
+    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike>::FrameIO> {
+        &self.output
     }
 
     fn frames(&self) -> Option<Vec<Self::CircuitFrame>> {

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -23,10 +23,9 @@ use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, 
 use std::sync::Arc;
 
 pub trait FrameLike: Sized {
-    // it's important to not define this as `Ptr` to avoid ambiguity
-    type FramePtr;
-    fn input(&self) -> &Self::FramePtr;
-    fn output(&self) -> &Self::FramePtr;
+    type FrameIO;
+    fn input(&self) -> &Self::FrameIO;
+    fn output(&self) -> &Self::FrameIO;
 }
 pub trait EvaluationStore {
     /// the type for the Store's pointers
@@ -61,7 +60,7 @@ pub trait MultiFrameTrait<F: LurkField, C: Coprocessor<F>>:
     /// The associated `Frame` type
     type EvalFrame: FrameLike;
     /// The associated `CircuitFrame` type
-    type CircuitFrame: FrameLike<FramePtr = <Self::EvalFrame as FrameLike>::FramePtr>;
+    type CircuitFrame: FrameLike<FrameIO = <Self::EvalFrame as FrameLike>::FrameIO>;
     /// The associated type which manages global allocations
     type GlobalAllocation;
     /// The associated type of allocated input and output to the circuit
@@ -86,9 +85,9 @@ pub trait MultiFrameTrait<F: LurkField, C: Coprocessor<F>>:
     ) -> Result<Vec<Self::EvalFrame>, ProofError>;
 
     /// Returns a public IO vector when equipped with the local store, and the Self::Frame's IO
-    fn to_io_vector(
+    fn io_to_scalar_vector(
         store: &Self::Store,
-        frames: &<Self::EvalFrame as FrameLike>::FramePtr,
+        io: &<Self::EvalFrame as FrameLike>::FrameIO,
     ) -> Result<Vec<F>, Self::StoreError>;
 
     /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
@@ -99,6 +98,9 @@ pub trait MultiFrameTrait<F: LurkField, C: Coprocessor<F>>:
 
     /// Returns a reference to the cached witness values
     fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>>;
+
+    /// The output of the last frame
+    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike>::FrameIO>;
 
     /// Iterates through the Self::CircuitFrame instances
     fn frames(&self) -> Option<Self::FrameIntoIter>;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -274,8 +274,9 @@ where
         store: &M::Store,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
-        let z0 = M::to_io_vector(store, frames[0].input()).map_err(|e| e.into())?;
-        let zi = M::to_io_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;
+        let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
+        let zi =
+            M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;
         let circuits = M::from_frames(self.reduction_count(), frames, store, lang.clone());
 
         let num_steps = circuits.len();
@@ -486,7 +487,8 @@ where
                         .into_iter()
                         .next()
                         .unwrap();
-                    let zi = M::to_io_vector(store, first_frame.input()).map_err(|e| e.into())?;
+                    let zi =
+                        M::io_to_scalar_vector(store, first_frame.input()).map_err(|e| e.into())?;
                     let zi_allocated: Vec<_> = zi
                         .iter()
                         .enumerate()
@@ -782,7 +784,7 @@ pub mod tests {
 
             assert!(delta == Delta::Equal);
         }
-        let output = previous_frame.unwrap().output();
+        let output = previous_frame.unwrap().output().unwrap();
 
         if let Some(expected_emitted) = expected_emitted {
             let emitted_vec: Vec<_> = frames


### PR DESCRIPTION
* Rename `FramePtr` to `FrameIO`
* Remove unused implementation of `FrameLike` for LEM's `MultiFrame`
* Add interface `MultiFrameTrait::output` and implement it for both instances